### PR TITLE
프로필, 홈 화면 시간표 30분단위 쪼개기

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,6 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
@@ -12,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/src/main/java/com/example/maite/EditTimetableFragment.kt
+++ b/app/src/main/java/com/example/maite/EditTimetableFragment.kt
@@ -17,6 +17,7 @@ import com.example.maite.model.TimetableEntry
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.launch
 import java.time.LocalDate
+import kotlin.math.ceil
 
 class EditTimetableFragment : Fragment() {
 
@@ -210,26 +211,26 @@ class EditTimetableFragment : Fragment() {
         // 선택한 요일 인덱스 (1: 월, 2: 화, ..., 7:일)
         val dayIndex = binding.spinnerDay.selectedItemPosition + 1
 
-        // TimetableEntry 생성
+        // TimetableEntry 생성 (수정된 버전 - 분 정보 포함)
         val entry = TimetableEntry(
             title = title,
             dayOfWeek = dayIndex,
             startHour = selectedStartHour,
+            startMinute = selectedStartMinute,
             endHour = selectedEndHour,
+            endMinute = selectedEndMinute,
             colorHex = defaultColor,
             location = location
         )
 
-        // 임시 시간표에 충돌 검사 후 추가
+        // 임시 시간표에 충돌 검사 후 추가 (수정된 충돌 검사 로직 - 분 단위)
         val conflictingEntry = temporaryEntries.find { existing ->
-            existing.dayOfWeek == entry.dayOfWeek && (
-                    // 새 일정이 기존 일정과 겹치는지 확인
-                    (entry.startHour < existing.endHour && entry.endHour > existing.startHour) ||
-                            // 기존 일정이 새 일정을 포함하는지 확인
-                            (existing.startHour <= entry.startHour && existing.endHour >= entry.endHour) ||
-                            // 새 일정이 기존 일정을 포함하는지 확인
-                            (entry.startHour <= existing.startHour && entry.endHour >= existing.endHour)
-                    )
+            existing.dayOfWeek == entry.dayOfWeek && isTimeConflict(
+                entryStart = entry.startHour * 60 + entry.startMinute,
+                entryEnd = entry.endHour * 60 + entry.endMinute,
+                existingStart = existing.startHour * 60 + existing.startMinute,
+                existingEnd = existing.endHour * 60 + existing.endMinute
+            )
         }
 
         if (conflictingEntry != null) {
@@ -242,6 +243,23 @@ class EditTimetableFragment : Fragment() {
             updateTimetablePreview()
             Toast.makeText(requireContext(), "일정이 추가되었습니다.", Toast.LENGTH_SHORT).show()
         }
+    }
+
+    // 시간 충돌 여부 확인 (분 단위)
+    private fun isTimeConflict(
+        entryStart: Int,
+        entryEnd: Int,
+        existingStart: Int,
+        existingEnd: Int
+    ): Boolean {
+        return (
+                // 새 일정이 기존 일정과 겹치는지 확인
+                (entryStart < existingEnd && entryEnd > existingStart) ||
+                        // 기존 일정이 새 일정을 포함하는지 확인
+                        (existingStart <= entryStart && existingEnd >= entryEnd) ||
+                        // 새 일정이 기존 일정을 포함하는지 확인
+                        (entryStart <= existingStart && entryEnd >= existingEnd)
+                )
     }
 
     // 바텀 시트 방식 시간 선택
@@ -262,7 +280,7 @@ class EditTimetableFragment : Fragment() {
     }
 
     private fun updateTimeDisplay() {
-        // 시간 형식 포맷팅 (09:00 형식)
+        // 시간 형식 포맷팅 (09:00 또는 09:30 형식)
         val startFormatted = String.format("%02d:%02d", selectedStartHour, selectedStartMinute)
         val endFormatted = String.format("%02d:%02d", selectedEndHour, selectedEndMinute)
 
@@ -277,27 +295,33 @@ class EditTimetableFragment : Fragment() {
         // 시간표 생성을 위한 데이터
         val entries = temporaryEntries
 
-        // 동적 시간 범위 계산하되 최소 9시부터 20시까지 표시
-        var minTime = 9
-        var maxTime = 23
+        // 동적 시간 범위 계산 (최소 9시부터 20시까지 표시)
+        var minHour = 9
+        var maxHour = 20
 
         // 일정이 있는 경우에만 범위 조정
         if (entries.isNotEmpty()) {
-            val startTimes = entries.map { it.startHour }
-            val endTimes = entries.map { it.endHour }
-
-            if (startTimes.min() < minTime) {
-                minTime = startTimes.min()
+            // 시작 시간 최소값 (시간 + 분/60으로 소수점 시간)
+            val startTimes = entries.map {
+                it.startHour + (it.startMinute / 60.0)
+            }
+            // 종료 시간 최대값 (시간 + 분/60으로 소수점 시간)
+            val endTimes = entries.map {
+                it.endHour + (it.endMinute / 60.0)
             }
 
-            if (endTimes.max() > maxTime) {
-                maxTime = endTimes.max()
+            if (startTimes.minOrNull()?.toInt() ?: minHour < minHour) {
+                minHour = (startTimes.minOrNull() ?: minHour.toDouble()).toInt()
+            }
+
+            if (ceil(endTimes.maxOrNull() ?: maxHour.toDouble()).toInt() > maxHour) {
+                maxHour = ceil(endTimes.maxOrNull() ?: maxHour.toDouble()).toInt()
             }
         }
 
         // 시간 범위가 넘어가면 제한 (0-23 범위 내로)
-        minTime = minTime.coerceIn(0, 23)
-        maxTime = maxTime.coerceIn(minTime + 1, 23)
+        minHour = minHour.coerceIn(0, 23)
+        maxHour = maxHour.coerceIn(minHour + 1, 23)
 
         // 시간표 테이블 생성
         val tableLayout = TableLayout(requireContext()).apply {
@@ -348,33 +372,43 @@ class EditTimetableFragment : Fragment() {
         }
         tableLayout.addView(headerRow)
 
-        // 시간대별 행 추가
-        for (hour in minTime..maxTime) {
+        // 시간대별 행 추가 (30분 단위로 변경)
+        for (timeSlot in (minHour * 2)..(maxHour * 2)) {
+            val hour = timeSlot / 2
+            val minute = (timeSlot % 2) * 30
+            val currentTimeInMinutes = hour * 60 + minute
+
             val row = TableRow(requireContext())
 
             // 시간 셀
             val timeCell = TextView(requireContext()).apply {
-                text = hour.toString()
+                text = String.format("%02d:%02d", hour, minute)
                 textSize = 10f
                 gravity = Gravity.CENTER
                 setBackgroundColor(Color.parseColor("#F5F5F5"))
                 layoutParams = TableRow.LayoutParams().apply {
                     width = 40
-                    height = 52 // 미리보기이므로 높이를 좀 더 작게
+                    height = 30 // 30분 단위이므로 높이 조정
                 }
             }
             row.addView(timeCell)
 
             // 요일별 셀
             for (day in 1 until weekDays.size) {
-                val entry = entries.find {
-                    (hour in it.startHour until it.endHour) && it.dayOfWeek == day
+                // 현재 시간대의 일정 찾기
+                val entry = entries.find { e ->
+                    val startTimeInMinutes = e.startHour * 60 + e.startMinute
+                    val endTimeInMinutes = e.endHour * 60 + e.endMinute
+
+                    e.dayOfWeek == day &&
+                            currentTimeInMinutes >= startTimeInMinutes &&
+                            currentTimeInMinutes < endTimeInMinutes
                 }
 
                 val cell = LinearLayout(requireContext()).apply {
                     layoutParams = TableRow.LayoutParams().apply {
                         width = 0
-                        height = 52 // 미리보기이므로 높이를 좀 더 작게
+                        height = 30 // 30분 단위이므로 높이 조정
                         weight = 1f
                     }
                     gravity = Gravity.CENTER
@@ -384,12 +418,42 @@ class EditTimetableFragment : Fragment() {
                         setBackgroundColor(Color.parseColor(entry.colorHex))
                         alpha = 0.85f
 
+                        // 일정 시작 시간인 경우에만 제목 표시
+                        val isStartTime = (
+                                currentTimeInMinutes == entry.startHour * 60 + entry.startMinute
+                                )
+
+                        if (isStartTime) {
+                            addView(TextView(requireContext()).apply {
+                                text = entry.title
+                                textSize = 9f
+                                gravity = Gravity.CENTER
+                                setTextColor(Color.WHITE)
+                                ellipsize = android.text.TextUtils.TruncateAt.END
+                                maxLines = 1
+                                setPadding(2, 2, 2, 2)
+                            })
+                        }
+
                         // 선택 가능하도록 설정
                         setOnClickListener {
                             // 이전에 선택된 항목이 있으면 강조 해제
                             selectedEntry?.let { prevEntry ->
-                                val prevCell = findCell(tableLayout, prevEntry)
-                                prevCell?.alpha = 0.85f
+                                // 모든 셀을 찾아서 강조 해제 (findCell 사용 안 함)
+                                val childCount = tableLayout.childCount
+                                for (i in 0 until childCount) {
+                                    val tableRow = tableLayout.getChildAt(i) as? TableRow
+                                    tableRow?.let { r ->
+                                        val cellIndex = prevEntry.dayOfWeek
+                                        if (cellIndex < r.childCount) {
+                                            // 셀이 일정에 해당하면 알파값 원복
+                                            val cell = r.getChildAt(cellIndex)
+                                            if (cell is LinearLayout && cell.background != null) {
+                                                cell.alpha = 0.85f
+                                            }
+                                        }
+                                    }
+                                }
                             }
 
                             // 새 항목 선택 및 강조
@@ -397,17 +461,6 @@ class EditTimetableFragment : Fragment() {
                             alpha = 1.0f
                             Toast.makeText(context, "${entry.title} 선택됨", Toast.LENGTH_SHORT).show()
                         }
-
-                        // 일정 제목 표시 (미리보기이므로 글자 크기 작게)
-                        addView(TextView(requireContext()).apply {
-                            text = entry.title
-                            textSize = 9f
-                            gravity = Gravity.CENTER
-                            setTextColor(Color.WHITE)
-                            ellipsize = android.text.TextUtils.TruncateAt.END
-                            maxLines = 1
-                            setPadding(2, 2, 2, 2)
-                        })
                     } else {
                         // 빈 셀
                         setBackgroundResource(R.drawable.timetable_cell_border)
@@ -421,23 +474,6 @@ class EditTimetableFragment : Fragment() {
         }
 
         timetableLayout.addView(tableLayout)
-    }
-
-    // 특정 항목에 해당하는 셀 찾기
-    private fun findCell(tableLayout: TableLayout, entry: TimetableEntry): View? {
-        for (hour in entry.startHour until entry.endHour) {
-            val rowIndex = hour - 9 + 1 // 9시가 첫번째 행이므로 +1 (헤더 행 고려)
-            if (rowIndex >= 0 && rowIndex < tableLayout.childCount) {
-                val row = tableLayout.getChildAt(rowIndex) as? TableRow
-                row?.let {
-                    val cellIndex = entry.dayOfWeek // 요일 인덱스 사용
-                    if (cellIndex < it.childCount) {
-                        return it.getChildAt(cellIndex)
-                    }
-                }
-            }
-        }
-        return null
     }
 
     private fun showConflictDialog(existing: TimetableEntry, new: TimetableEntry) {

--- a/app/src/main/java/com/example/maite/EditTimetableFragment.kt
+++ b/app/src/main/java/com/example/maite/EditTimetableFragment.kt
@@ -295,9 +295,9 @@ class EditTimetableFragment : Fragment() {
         // 시간표 생성을 위한 데이터
         val entries = temporaryEntries
 
-        // 동적 시간 범위 계산 (최소 9시부터 20시까지 표시)
+
         var minHour = 9
-        var maxHour = 20
+        var maxHour = 24
 
         // 일정이 있는 경우에만 범위 조정
         if (entries.isNotEmpty()) {

--- a/app/src/main/java/com/example/maite/HomeFragment.kt
+++ b/app/src/main/java/com/example/maite/HomeFragment.kt
@@ -18,6 +18,7 @@ import com.example.maite.data.model.MeetingItem
 import com.example.maite.data.model.MeetingProposal
 import com.example.maite.model.TimetableEntry
 import com.example.maite.ui.home.HomeViewModel
+import kotlin.math.ceil
 
 class HomeFragment : Fragment() {
 
@@ -103,32 +104,38 @@ class HomeFragment : Fragment() {
         }
     }
 
-    // 시간표 렌더링 메서드
+    // 시간표 렌더링 메서드 (30분 단위로 수정)
     private fun renderTimetable(entries: List<TimetableEntry>) {
         val timetableLayout = binding.flTimetable
         timetableLayout.removeAllViews()
 
         // 동적 시간 범위 계산
-        var minTime = 9  // 기본 최소 시간 (9시)
-        var maxTime = 20 // 기본 최대 시간 (20시)
+        var minHour = 9  // 기본 최소 시간 (9시)
+        var maxHour = 20 // 기본 최대 시간 (20시)
 
         // 일정이 있는 경우 시간 범위 조정
         if (entries.isNotEmpty()) {
-            val startTimes = entries.map { it.startHour }
-            val endTimes = entries.map { it.endHour }
-
-            if (startTimes.min() < minTime) {
-                minTime = startTimes.min()
+            // 시작 시간 최소값 (시간 + 분/60으로 소수점 시간)
+            val startTimes = entries.map {
+                it.startHour + (it.startMinute / 60.0)
+            }
+            // 종료 시간 최대값 (시간 + 분/60으로 소수점 시간)
+            val endTimes = entries.map {
+                it.endHour + (it.endMinute / 60.0)
             }
 
-            if (endTimes.max() > maxTime) {
-                maxTime = endTimes.max()
+            if ((startTimes.minOrNull() ?: minHour.toDouble()) < minHour) {
+                minHour = (startTimes.minOrNull() ?: minHour.toDouble()).toInt()
+            }
+
+            if (ceil(endTimes.maxOrNull() ?: maxHour.toDouble()).toInt() > maxHour) {
+                maxHour = ceil(endTimes.maxOrNull() ?: maxHour.toDouble()).toInt()
             }
         }
 
         // 시간 범위가 넘어가면 제한 (0-23 범위 내로)
-        minTime = minTime.coerceIn(0, 23)
-        maxTime = maxTime.coerceIn(minTime + 1, 23)
+        minHour = minHour.coerceIn(0, 23)
+        maxHour = maxHour.coerceIn(minHour + 1, 23)
 
         // 시간표 테이블 생성
         val tableLayout = TableLayout(requireContext()).apply {
@@ -179,33 +186,43 @@ class HomeFragment : Fragment() {
         }
         tableLayout.addView(headerRow)
 
-        // 동적으로 계산된 시간대 범위
-        for (hour in minTime..maxTime) {
+        // 시간대별 행 추가 (30분 단위로 변경)
+        for (timeSlot in (minHour * 2)..(maxHour * 2)) {
+            val hour = timeSlot / 2
+            val minute = (timeSlot % 2) * 30
+            val currentTimeInMinutes = hour * 60 + minute
+
             val row = TableRow(requireContext())
 
-            // 시간 셀
+            // 시간 셀 - 정시(00분)에만 시간 표시
             val timeCell = TextView(requireContext()).apply {
-                text = hour.toString()
+                text = if (minute == 0) hour.toString() else ""
                 textSize = 12f // 폰트 크기 증가
                 gravity = Gravity.CENTER
                 setBackgroundColor(Color.parseColor("#F5F5F5"))
                 layoutParams = TableRow.LayoutParams().apply {
                     width = 40
-                    height = 65 // 높이 더 증가
+                    height = 35 // 30분 단위이므로 높이 조정 (기존 65의 절반보다 약간 큰 값)
                 }
             }
             row.addView(timeCell)
 
             // 요일별 셀
             for (day in 1 until weekDays.size) {
-                val entry = entries.find {
-                    (hour in it.startHour until it.endHour) && it.dayOfWeek == day
+                // 현재 시간대의 일정 찾기 (30분 단위 고려)
+                val entry = entries.find { e ->
+                    val startTimeInMinutes = e.startHour * 60 + e.startMinute
+                    val endTimeInMinutes = e.endHour * 60 + e.endMinute
+
+                    e.dayOfWeek == day &&
+                            currentTimeInMinutes >= startTimeInMinutes &&
+                            currentTimeInMinutes < endTimeInMinutes
                 }
 
                 val cell = LinearLayout(requireContext()).apply {
                     layoutParams = TableRow.LayoutParams().apply {
                         width = 0
-                        height = 65 // 높이 더 증가
+                        height = 35 // 30분 단위이므로 높이 조정
                         weight = 1f
                     }
                     gravity = Gravity.CENTER
@@ -215,16 +232,22 @@ class HomeFragment : Fragment() {
                         setBackgroundColor(Color.parseColor(entry.colorHex))
                         alpha = 0.85f
 
-                        // 일정 제목 표시
-                        addView(TextView(requireContext()).apply {
-                            text = entry.title
-                            textSize = 11f // 폰트 크기 증가
-                            gravity = Gravity.CENTER
-                            setTextColor(Color.WHITE)
-                            ellipsize = android.text.TextUtils.TruncateAt.END
-                            maxLines = 1
-                            setPadding(2, 2, 2, 2)
-                        })
+                        // 일정 시작 시간인 경우에만 제목 표시
+                        val isStartTime = (
+                                currentTimeInMinutes == entry.startHour * 60 + entry.startMinute
+                                )
+
+                        if (isStartTime) {
+                            addView(TextView(requireContext()).apply {
+                                text = entry.title
+                                textSize = 11f // 폰트 크기 증가
+                                gravity = Gravity.CENTER
+                                setTextColor(Color.WHITE)
+                                ellipsize = android.text.TextUtils.TruncateAt.END
+                                maxLines = 1
+                                setPadding(2, 2, 2, 2)
+                            })
+                        }
                     } else {
                         // 빈 셀
                         setBackgroundResource(R.drawable.timetable_cell_border)

--- a/app/src/main/java/com/example/maite/ProfileFragment.kt
+++ b/app/src/main/java/com/example/maite/ProfileFragment.kt
@@ -18,6 +18,7 @@ import com.example.maite.model.TimetableEntry
 import com.example.maite.model.UserInfo
 import com.example.maite.ui.profile.EditTimetableFragment
 import com.example.maite.ui.profile.ProfileViewModel
+import kotlin.math.ceil
 
 class ProfileFragment : Fragment() {
 
@@ -74,31 +75,38 @@ class ProfileFragment : Fragment() {
         }
     }
 
+    // 30분 단위로 시간표를 표시하도록 수정
     private fun createTimetable(entries: List<TimetableEntry>) {
         val tableLayout = binding.timetableLayout
         tableLayout.removeAllViews()
 
         // 동적 시간 범위 계산
-        var minTime = 9 // 기본 최소 시간 (9시)
-        var maxTime = 24
+        var minHour = 9 // 기본 최소 시간 (9시)
+        var maxHour = 24
 
-        // 일정이 있는 경우 시간 범위 조정
+        // 일정이 있는 경우에만 범위 조정
         if (entries.isNotEmpty()) {
-            val startTimes = entries.map { it.startHour }
-            val endTimes = entries.map { it.endHour }
-
-            if (startTimes.min() < minTime) {
-                minTime = startTimes.min()
+            // 시작 시간 최소값 (시간 + 분/60으로 소수점 시간)
+            val startTimes = entries.map {
+                it.startHour + (it.startMinute / 60.0)
+            }
+            // 종료 시간 최대값 (시간 + 분/60으로 소수점 시간)
+            val endTimes = entries.map {
+                it.endHour + (it.endMinute / 60.0)
             }
 
-            if (endTimes.max() > maxTime) {
-                maxTime = endTimes.max()
+            if ((startTimes.minOrNull() ?: minHour.toDouble()) < minHour) {
+                minHour = (startTimes.minOrNull() ?: minHour.toDouble()).toInt()
+            }
+
+            if (ceil(endTimes.maxOrNull() ?: maxHour.toDouble()).toInt() > maxHour) {
+                maxHour = ceil(endTimes.maxOrNull() ?: maxHour.toDouble()).toInt()
             }
         }
 
         // 시간 범위가 넘어가면 제한 (0-23 범위 내로)
-        minTime = minTime.coerceIn(0, 23)
-        maxTime = maxTime.coerceIn(minTime + 1, 23)
+        minHour = minHour.coerceIn(0, 23)
+        maxHour = maxHour.coerceIn(minHour + 1, 23)
 
         // 시간 열 너비 계산
         val timeColWidth = calculateTextWidth("00")
@@ -118,14 +126,18 @@ class ProfileFragment : Fragment() {
         }
         tableLayout.addView(headerRow)
 
-        // 시간대별 행 추가
-        val cellHeight = resources.getDimensionPixelSize(R.dimen.timetable_cell_height)
+        val cellHeight = resources.getDimensionPixelSize(R.dimen.timetable_cell_height) / 2 // 높이를 절반으로 조정
 
-        for (hour in minTime..maxTime) {
+        for (timeSlot in (minHour * 2)..(maxHour * 2)) {
+            val hour = timeSlot / 2
+            val minute = (timeSlot % 2) * 30
+            val currentTimeInMinutes = hour * 60 + minute
+
             val row = TableRow(context)
 
-            // 시간 표시 열
-            val timeCell = createTextView(hour.toString(), timeColWidth)
+            // 시간 표시 열 - 정시(00분)에만 시간 표시
+            val timeText = if (minute == 0) hour.toString() else ""
+            val timeCell = createTextView(timeText, timeColWidth, cellHeight)
             timeCell.setBackgroundColor(Color.parseColor("#F5F5F5"))
             timeCell.textSize = 10f
             timeCell.setTextColor(Color.parseColor("#555555"))
@@ -133,38 +145,46 @@ class ProfileFragment : Fragment() {
 
             // 요일별 셀 추가
             for (day in 1 until weekDays.size) {
-                // 해당 요일, 시간의 일정 찾기
-                val matched = entries.find {
-                    (hour in it.startHour until it.endHour) && it.dayOfWeek == day
+                // 해당 요일, 시간의 일정 찾기 (30분 단위 고려)
+                val matched = entries.find { e ->
+                    val startTimeInMinutes = e.startHour * 60 + e.startMinute
+                    val endTimeInMinutes = e.endHour * 60 + e.endMinute
+
+                    e.dayOfWeek == day &&
+                            currentTimeInMinutes >= startTimeInMinutes &&
+                            currentTimeInMinutes < endTimeInMinutes
                 }
 
-                // 셀 컨테이너 생성
+                // 셀 컨테이너 생성 - 홈 프라그먼트와 동일한 방식으로 변경
                 val cell = LinearLayout(context).apply {
                     layoutParams = TableRow.LayoutParams(0, cellHeight, 1f)
                     gravity = Gravity.CENTER
-                    setPadding(2, 2, 2, 2)
-                    setBackgroundResource(R.drawable.timetable_cell_border)
-                }
 
-                // 일정이 있는 경우 내용 추가
-                if (matched != null) {
-                    val inner = TextView(context).apply {
-                        text = matched.title
-                        textSize = 10f
-                        gravity = Gravity.CENTER
+                    if (matched != null) {
+                        // 일정이 있는 경우
                         setBackgroundColor(Color.parseColor(matched.colorHex))
-                        setTextColor(Color.WHITE)
-                        layoutParams = LinearLayout.LayoutParams(
-                            LinearLayout.LayoutParams.MATCH_PARENT,
-                            LinearLayout.LayoutParams.MATCH_PARENT
-                        )
-                        setPadding(4, 4, 4, 4)
-                        maxLines = 1
-                        isSingleLine = true
-                        alpha = 0.85f  // 약간의 투명도
-                        elevation = 2f  // 약간의 그림자 효과
+                        alpha = 0.85f
+
+                        // 일정 시작 시간인 경우에만 제목 표시
+                        val isStartTime = (
+                                currentTimeInMinutes == matched.startHour * 60 + matched.startMinute
+                                )
+
+                        if (isStartTime) {
+                            addView(TextView(context).apply {
+                                text = matched.title
+                                textSize = 11f
+                                gravity = Gravity.CENTER
+                                setTextColor(Color.WHITE)
+                                ellipsize = android.text.TextUtils.TruncateAt.END
+                                maxLines = 1
+                                setPadding(2, 2, 2, 2)
+                            })
+                        }
+                    } else {
+                        // 빈 셀 - 홈 프라그먼트와 같이 테두리 설정
+                        setBackgroundResource(R.drawable.timetable_cell_border)
                     }
-                    cell.addView(inner)
                 }
 
                 row.addView(cell)
@@ -174,17 +194,21 @@ class ProfileFragment : Fragment() {
         }
     }
 
-    private fun createTextView(text: String, width: Int = 0): TextView {
+    // 셀 생성 함수 수정 - 요일 헤더와 시간 헤더에 사용됨
+    private fun createTextView(text: String, width: Int = 0, height: Int = 0): TextView {
+        val cellHeight = if (height > 0) height else resources.getDimensionPixelSize(R.dimen.timetable_cell_height)
+
         return TextView(context).apply {
             this.text = text
             gravity = Gravity.CENTER
             layoutParams = TableRow.LayoutParams(
                 if (width > 0) width + 8 else 0,
-                resources.getDimensionPixelSize(R.dimen.timetable_cell_height)
+                cellHeight
             ).apply {
                 if (width <= 0) weight = 1f
             }
-            setBackgroundResource(R.drawable.timetable_cell_border)
+            // 헤더용 셀에 배경색만 적용 (테두리 없이)
+            setBackgroundColor(Color.WHITE)
             maxLines = 1
             isSingleLine = true
         }

--- a/app/src/main/java/com/example/maite/TimetableEntry.kt
+++ b/app/src/main/java/com/example/maite/TimetableEntry.kt
@@ -2,9 +2,21 @@ package com.example.maite.model
 
 data class TimetableEntry(
     val title: String,
-    val dayOfWeek: Int,   // 1:월, 2:화, ..., 7:일
-    val startHour: Int,   // 예: 10
-    val endHour: Int,     // 예: 12
-    val colorHex: String, // "#A5BEF5" 형식
+    val dayOfWeek: Int,      // 1:월, 2:화, ..., 7:일
+    val startHour: Int,      // 시작 시간 (시)
+    val startMinute: Int,    // 시작 시간 (분) - 0 또는 30
+    val endHour: Int,        // 종료 시간 (시)
+    val endMinute: Int,      // 종료 시간 (분) - 0 또는 30
+    val colorHex: String,    // "#A5BEF5" 형식
     val location: String = "" // 장소 정보 추가
-)
+) {
+    // 기존 생성자 호환성을 위한 보조 생성자 (분 정보가 없는 경우 0으로 초기화)
+    constructor(
+        title: String,
+        dayOfWeek: Int,
+        startHour: Int,
+        endHour: Int,
+        colorHex: String,
+        location: String = ""
+    ) : this(title, dayOfWeek, startHour, 0, endHour, 0, colorHex, location)
+}


### PR DESCRIPTION
## ✔️ 작업 내용
- 1시간 단위로 시간표 반영이 됐던 것을 30분단위로 쪼개어 기능에 이질감이 없도록 수정했습니다.
- 디자인 일관성은 유지하였습니다.

## 💬 참고 사항 <!-- 리뷰어에게 할 말을 작성해주세요. -->
- 예를 들어, 9:30~10:00으로 저장해도 시간표 반영은 9:00~10:00로 반영되던 단점을, 30분단위로 더 쪼개어 보완하였습니다.
- 
