### PR TITLE
홈, 프로필, 시간표 수정하기 화면 성능 최적화

### DIFF
--- a/app/src/main/java/com/example/maite/HomeFragment.kt
+++ b/app/src/main/java/com/example/maite/HomeFragment.kt
@@ -69,19 +69,10 @@ class HomeFragment : Fragment() {
         val userId = preferencesUtil.getUserId()
 
         if (userId != null) {
-            // 서버에서 시간표 로드
+            // 서버에서 시간표 로드 (한 번만)
             lifecycleScope.launch {
                 profileViewModel.loadTimetableFromServer(userId)
             }
-
-            // 5초 후에도 시간표가 비어있으면 다시 로드 시도
-            Handler(Looper.getMainLooper()).postDelayed({
-                if (viewModel.timetableEntries.value?.isEmpty() == true) {
-                    lifecycleScope.launch {
-                        profileViewModel.loadTimetableFromServer(userId)
-                    }
-                }
-            }, 5000)
         } else {
 
             // 사용자 ID가 없는 경우 로그인 필요 안내
@@ -283,7 +274,6 @@ class HomeFragment : Fragment() {
         
         // 초기 회의 목록 로드 (HomeViewModel 초기화 후)
         viewModel.loadNearestMeeting()
-        Log.d("HomeFragment", "초기 회의 목록 로드 시작")
 
         // 회의방 참가 이벤트 관찰 (토스트 메시지 표시)
         viewModel.roomJoinEvent.observe(viewLifecycleOwner) { roomName ->
@@ -322,9 +312,10 @@ class HomeFragment : Fragment() {
             }
         }
 
-        // 로딩 상태 관찰
+        // 로딩 상태 관찰 (성능 최적화: 홈화면에서는 프로그레스바 비활성화)
         viewModel.isLoading.observe(viewLifecycleOwner) { isLoading ->
-            binding.progressBar.visibility = if (isLoading) View.VISIBLE else View.GONE
+            // 홈화면 성능 향상을 위해 프로그레스바 숨김
+            binding.progressBar.visibility = View.GONE
         }
 
         // 오류 메시지 관찰
@@ -587,7 +578,6 @@ class HomeFragment : Fragment() {
                         // 잠시 대기 후 서버에서 업데이트 된 회의 목록을 가져오기
                         android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
                             viewModel.loadNearestMeeting()
-                            Log.d("HomeFragment", "회의 목록 새로 가져오기 완료")
                         }, 500) // 0.5초 대기 후 새로고침
 
                         // 성공 메시지 표시
@@ -643,7 +633,6 @@ class HomeFragment : Fragment() {
                         // 회의 목록 새로고침 (대기 시간 증가)
                         Handler(Looper.getMainLooper()).postDelayed({
                             viewModel.loadNearestMeeting()
-                            Log.d("HomeFragment", "NotificationViewModel을 통한 회의 목록 새로고침 완료")
                         }, 1500) // 1.5초로 증가
                     }
                     NotificationType.ROOM_INVITE -> {

--- a/app/src/main/java/com/example/maite/ProfileFragment.kt
+++ b/app/src/main/java/com/example/maite/ProfileFragment.kt
@@ -247,121 +247,53 @@ class ProfileFragment : Fragment(), ProfileEditBottomSheet.ProfileImageUpdateLis
             .commit()
     }
 
-    // 프로필 이미지 업데이트 콜백
+    // 프로필 이미지 업데이트 콜백 (성능 최적화)
     override fun onProfileImageUpdated() {
-        try {
-            val preferencesUtil = PreferencesUtil(requireContext())
-            
-            // 1. Glide 캐시 완전히 초기화 (매우 중요 - 이미지 수정 후 반드시 새로고침되도록)
-            try {
-                // 메인 스레드에서 메모리 캐시 초기화
-                Glide.get(requireContext()).clearMemory()
-                
-                // 백그라운드 스레드에서 디스크 캐시 초기화 
-                Thread {
-                    try {
-                        Glide.get(requireContext()).clearDiskCache()
-                    } catch (e: Exception) {
-                        // 디스크 캐시 초기화 실패 시 무시
-                    }
-                }.start()
-            } catch (e: Exception) {
-                // Glide 캐시 초기화 실패 시 무시
-            }
-            
-            // 2. 임시 URI 확인 및 처리 (바텀시트에서 임시 저장한 값)
-            val tempImageUri = preferencesUtil.getString("user_profile_image_uri_temp")
-            if (!tempImageUri.isNullOrEmpty()) {
-                // 임시 URI를 정식 URI로 복사 (PreferencesUtil 메소드 사용)
-                preferencesUtil.saveProfileImageUri(tempImageUri)
-                preferencesUtil.removeString("user_profile_image_uri_temp")
-            }
-            
-            // 3. 현재 URI 또는 URL 상태 확인
-            val currentUri = preferencesUtil.getProfileImageUri()
-            val currentUrl = preferencesUtil.getProfileImageUrl()
-            
-            // 4. URI로 이미지 로드 시도
-            if (!currentUri.isNullOrEmpty()) {
-                try {
-                    val uri = Uri.parse(currentUri)
-                    
-                    // 캐시 사용 안 함 + 서명 추가로 강제 새로고침
-                    Glide.with(this)
-                        .load(uri)
-                        .circleCrop()
-                        .skipMemoryCache(true)
-                        .diskCacheStrategy(com.bumptech.glide.load.engine.DiskCacheStrategy.NONE)
-                        .signature(com.bumptech.glide.signature.ObjectKey(System.currentTimeMillis()))
-                        .placeholder(R.drawable.img_profile_default)
-                        .error(R.drawable.img_profile_default)
-                        .into(binding.ivProfile)
-                    
-                    return
-                } catch (e: Exception) {
-                    // URI 이미지 로드 실패 시 차선책으로 URL 시도
-                }
-            }
-            
-            // 5. URL로 이미지 로드 시도
-            if (!currentUrl.isNullOrEmpty()) {
-                try {
-                    // 캐시 사용 안 함 + 서명 추가로 강제 새로고침
-                    Glide.with(this)
-                        .load(currentUrl)
-                        .circleCrop()
-                        .skipMemoryCache(true)
-                        .diskCacheStrategy(com.bumptech.glide.load.engine.DiskCacheStrategy.NONE)
-                        .signature(com.bumptech.glide.signature.ObjectKey(System.currentTimeMillis()))
-                        .placeholder(R.drawable.img_profile_default)
-                        .error(R.drawable.img_profile_default)
-                        .into(binding.ivProfile)
-                        
-                    return
-                } catch (e: Exception) {
-                    // URL 이미지 로드 실패 시 서버에서 새로고침
-                }
-            }
-            
-            // 6. 모든 시도 실패 시 서버에서 정보 새로고침
-            val userId = preferencesUtil.getUserId()
-            if (userId != null && userId != 0L) {
-                viewModel.loadUserInfo(userId)
-            } else {
-                // 테스트 사용자 ID로 정보 불러오기
-                val testUserId = 1L
-                viewModel.loadUserInfo(testUserId)
-            }
-        } catch (e: Exception) {
-            // 프로필 이미지 업데이트 실패 시 무시
+    try {
+    val preferencesUtil = PreferencesUtil(requireContext())
+    
+    // 임시 URI 확인 및 처리
+    val tempImageUri = preferencesUtil.getString("user_profile_image_uri_temp")
+    if (!tempImageUri.isNullOrEmpty()) {
+    preferencesUtil.saveProfileImageUri(tempImageUri)
+    preferencesUtil.removeString("user_profile_image_uri_temp")
+    }
+    
+    // 현재 URI 또는 URL로 이미지 로드
+    val currentUri = preferencesUtil.getProfileImageUri()
+    val currentUrl = preferencesUtil.getProfileImageUrl()
+    
+    if (!currentUri.isNullOrEmpty()) {
+    try {
+            val uri = Uri.parse(currentUri)
+        Glide.with(this)
+                .load(uri)
+                .circleCrop()
+                .signature(com.bumptech.glide.signature.ObjectKey(System.currentTimeMillis()))
+                .placeholder(R.drawable.img_profile_default)
+                .error(R.drawable.img_profile_default)
+            .into(binding.ivProfile)
+        return
+    } catch (e: Exception) {
+            // URI 로드 실패 시 URL 시도
         }
+    }
+    
+    if (!currentUrl.isNullOrEmpty()) {
+        loadProfileImageFromUrl(currentUrl)
+    }
+    } catch (e: Exception) {
+    // 프로필 이미지 업데이트 실패 시 무시
+    }
     }
 
     override fun onResume() {
         super.onResume()
         
-        // Glide 캐시 초기화 (중요 - 프로필 이미지 재로드 위해)
-        try {
-            // 메모리 캐시는 메인 스레드에서 처리
-            Glide.get(requireContext()).clearMemory()
-            
-            // 디스크 캐시는 백그라운드 스레드에서 처리
-            Thread {
-                try {
-                    Glide.get(requireContext()).clearDiskCache()
-                } catch (e: Exception) {
-                    // 디스크 캐시 지우기 실패 시 무시
-                }
-            }.start()
-        } catch (e: Exception) {
-            // Glide 캐시 지우기 실패 시 무시
-        }
-        
-        // 프로필 이미지 정보 가져오기
+        // 성능 최적화: 프로필 이미지만 간단하게 새로고침
         val preferencesUtil = PreferencesUtil(requireContext())
-        val userId = preferencesUtil.getUserId()
         
-        // 먼저 로컬 URI 확인 (최우선)
+        // 로컬 URI가 있으면 우선 사용
         val localImageUri = preferencesUtil.getProfileImageUri()
         if (!localImageUri.isNullOrEmpty()) {
             try {
@@ -369,40 +301,15 @@ class ProfileFragment : Fragment(), ProfileEditBottomSheet.ProfileImageUpdateLis
                 Glide.with(this)
                     .load(uri)
                     .circleCrop()
-                    .skipMemoryCache(true)
-                    .diskCacheStrategy(com.bumptech.glide.load.engine.DiskCacheStrategy.NONE)
-                    .signature(com.bumptech.glide.signature.ObjectKey(System.currentTimeMillis()))
                     .placeholder(R.drawable.img_profile_default)
                     .error(R.drawable.img_profile_default)
                     .into(binding.ivProfile)
-                
             } catch (e: Exception) {
-                // 로딩 실패 시 URL 사용 시도
-            }
-        } 
-        
-        // 로컬 URI가 없거나 로드 실패한 경우 URL 사용
-        val cachedImageUrl = preferencesUtil.getProfileImageUrl()
-        if (!cachedImageUrl.isNullOrEmpty()) {
-            loadProfileImageFromUrl(cachedImageUrl)
-        }
-        
-        // 서버에서 사용자 정보 업데이트
-        if (userId != null && userId != 0L) {
-            // 사용자 정보 로딩 (프로필 이미지 URL 포함)
-            viewModel.loadUserInfo(userId)
-            
-            // 시간표 로딩
-            lifecycleScope.launch {
-                viewModel.loadTimetableFromServer(userId)
-            }
-        } else {
-            // 테스트 사용자 ID를 사용
-            val testUserId = 1L
-            viewModel.loadUserInfo(testUserId)
-            
-            lifecycleScope.launch {
-                viewModel.loadTimetableFromServer(testUserId)
+                // 로딩 실패 시 캐시된 URL 사용
+                val cachedImageUrl = preferencesUtil.getProfileImageUrl()
+                if (!cachedImageUrl.isNullOrEmpty()) {
+                    loadProfileImageFromUrl(cachedImageUrl)
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/maite/ui/profile/EditTimetableFragment.kt
+++ b/app/src/main/java/com/example/maite/ui/profile/EditTimetableFragment.kt
@@ -2,7 +2,7 @@ package com.example.maite.ui.profile
 
 import android.graphics.Color
 import android.os.Bundle
-import android.util.Log
+
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
@@ -281,11 +281,8 @@ class EditTimetableFragment : Fragment() {
                         Toast.makeText(requireContext(), event.message, Toast.LENGTH_LONG).show()
                     }
                     is ProfileViewModel.TimetableEvent.SyncCompleted -> {
-                        // 동기화 완료
-                        if (event.success) {
-                            Log.d("EditTimetableFragment", "서버 동기화 성공: ${event.message}")
-                        } else {
-                            Log.e("EditTimetableFragment", "서버 동기화 실패: ${event.message}")
+                        // 동기화 완료 (성능 최적화: 로그 제거)
+                        if (!event.success) {
                             Toast.makeText(requireContext(), "동기화 오류: ${event.message}", Toast.LENGTH_SHORT).show()
                         }
                     }
@@ -621,8 +618,7 @@ class EditTimetableFragment : Fragment() {
                 )
             }
         } catch (e: Exception) {
-            Log.e("EditTimetableFragment", "동적 높이 조정 중 오류 발생", e)
-            // 기본 높이 사용
+            // 동적 높이 조정 실패 시 기본 높이 사용
             tableLayout.layoutParams = ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT


### PR DESCRIPTION
## ✔️ 작업 내용
- HomeFragment.kt
1. 5초 후 재시도 로직 제거 → API 중복 호출 방지
2. 홈화면 프로그레스바 제거 → 더 빠른 로딩 경험
3. 3개의 Log.d 메시지 제거 → 불필요한 로그 출력 제거
- ProfileFragment.kt
1. onResume에서 중복 API 호출 제거 → 서버 부하 감소
2. Glide 캐시 초기화 로직 대폭 단순화 → 이미지 로딩 속도 향상
3. 복잡한 프로필 이미지 처리 로직 간소화 → 메모리 사용량 최적화

-EditTimetableFragment.kt
1. 모든 Log 메시지 제거 → 성능 향상
2. 불필요한 로그 import 제거 → 코드 경량화


## 💬 참고 사항 <!-- 리뷰어에게 할 말을 작성해주세요. -->
- 내용을 작성해주세요.
- 
